### PR TITLE
Gzip compress responses to speedup GETs

### DIFF
--- a/nginx_app.conf
+++ b/nginx_app.conf
@@ -1,3 +1,9 @@
+gzip on;
+gzip_min_length 500;
+gzip_proxied any;
+gzip_comp_level 6;
+gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
 location / {
     #root   /var/www/mysite/public;
     # try to serve file directly, fallback to rewrite
@@ -7,9 +13,11 @@ location / {
 location @rewriteapp {
     # rewrite all to index.php
     rewrite ^(.*)$ /index.php/$1 last;
-}
+  }
 
 location ~ ^/(index|config)\.php(/|$) {
-    try_files @heroku-fcgi @heroku-fcgi;
-    internal;
+  try_files @heroku-fcgi @heroku-fcgi;
+  internal;
 }
+
+


### PR DESCRIPTION
Measurements on heroku: 

```
ab -c 64 -n 1000 <host>/products\?limit\=50
```

Before change: 

```
  50%    883
  66%    919
  75%    952
  80%   1050
  90%   1404
  95%   1540
  98%   1790
  99%   2128
 100%   2703 (longest request)
```

after change: 

```
Percentage of the requests served within a certain time (ms)
  50%    997
  66%   1018
  75%   1032
  80%   1055
  90%   1163
  95%   1249
  98%   1493
  99%   1584
 100%   3387 (longest request)
```